### PR TITLE
#75 [FIX] i18n.js 경로 오타 수정 및 ESLint 에러 해결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,11 +23,5 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@package-name/*": ["packages/package-name/src/*"]
-    }
   }
 }

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import translationEN from './locales/en/translation.json';
-import translationKO from './locales/ko/translation.json';
+import translationEN from './en/translation.json';
+import translationKO from './ko/translation.json';
 
 const resources = {
   en: {


### PR DESCRIPTION
## 작업 내용
- i18n.js의 import 경로 수정
	- ./locales/en/translation.json => ./en/translation.json 경로 수
- ESLint 에러 해결
	```
	[eslint] ESLint configuration in .eslintrc.json is invalid:
	Unexpected top-level property "compilerOptions".
	```